### PR TITLE
bugfix #26: clear posts list after moving to other page

### DIFF
--- a/src/pages/posts/Posts.tsx
+++ b/src/pages/posts/Posts.tsx
@@ -6,7 +6,7 @@ import { Header } from '../../components/Header'
 import { Post } from '../../components/post'
 import { Spinner } from '../../components/Spinner'
 import { Typography } from '../../components/Typography'
-import { loadPagesNumber, loadPostsList, setCurrentPage } from '../../store/postsSlice'
+import { clearPostsData, loadPagesNumber, loadPostsList, setCurrentPage } from '../../store/postsSlice'
 import {
   selectCurrentPage,
   selectIsLoading,
@@ -35,6 +35,9 @@ export const Posts = () => {
 
   useEffect(() => {
     dispatch(loadPagesNumber())
+    return () => {
+      dispatch(clearPostsData())
+    }
   }, [])
 
   const handleLoadingPosts = () => dispatch(setCurrentPage(currentPage + 1))

--- a/src/pages/posts/SearchFilterParams/index.tsx
+++ b/src/pages/posts/SearchFilterParams/index.tsx
@@ -47,6 +47,7 @@ export const SearchBar: React.FC = () => {
               value={sortType.value}
               onChange={handleSortTypeClick}
               className={classes.radioInput}
+              checked={sortType.value === selectedSortType}
             />
             <span className={classes.searchAndSortBar__sortTypes__title}>{sortType.label}</span>
           </label>

--- a/src/store/postsSlice.tsx
+++ b/src/store/postsSlice.tsx
@@ -18,7 +18,7 @@ interface IPostsState {
 const initialState = {
   data: [],
   pagesAmount: 0,
-  sort: 'default',
+  sort: 'recent',
   currentPage: 1,
   isLoading: false,
 } as IPostsState

--- a/src/store/postsSlice.tsx
+++ b/src/store/postsSlice.tsx
@@ -44,10 +44,12 @@ export const postsSlice = createSlice({
     setIsLoading: (state, action: PayloadAction<boolean>) => {
       state.isLoading = action.payload
     },
+    clearPostsData: () => initialState,
   },
 })
 
-export const { addPosts, setPagesAmount, setSortType, setCurrentPage, setIsLoading } = postsSlice.actions
+export const { addPosts, setPagesAmount, setSortType, setCurrentPage, setIsLoading, clearPostsData } =
+  postsSlice.actions
 
 export const loadPostsList = (params: IPostsParams) => (dispatch: AppDispatch) => {
   dispatch(setIsLoading(true))


### PR DESCRIPTION
Fixed bug: After moving to the other page and returning back to the posts page, there were duplicating posts