### PR TITLE
Feature/#43 [Profile Page] implement upload user photo

### DIFF
--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -41,11 +41,13 @@ export const Post: React.FC<React.PropsWithChildren<IPost>> = ({ author, date, b
         <div className={styles.post__flex}>
           <div className={styles['post__author-center']}>
             <div>
-              <Avatar imageUrl={resolveProfileImagePath(author)} isSmall={true} />
+              <Link to={`${ROUTES.PROFILE}/${author}`}>
+                <Avatar imageUrl={resolveProfileImagePath(author)} isSmall={true} />{' '}
+              </Link>
             </div>
             <div className={styles['post__author-wrap-color']}>
               <span>posted by </span>
-              <Link to={ROUTES.PROFILE}> {author}</Link>
+              <Link to={`${ROUTES.PROFILE}/${author}`}> {author}</Link>
             </div>
           </div>
           <span className={styles['post__flex-date']}>{postDate}</span>

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -7,6 +7,7 @@ import { Avatar } from '../../components/Avatar'
 import { Container } from '../../components/Container'
 import { Header } from '../../components/Header'
 import { Spinner } from '../../components/Spinner'
+import { toasterService } from '../../components/Toast/ToastService'
 import { IUser } from '../../models/User'
 import { selectUser } from '../../store/selectors/users'
 
@@ -24,8 +25,11 @@ interface IProfile {
 export const Profile: React.FC<React.PropsWithChildren<IProfile>> = ({ match }) => {
   const [user, setUser] = useState<IUser>({})
   const [loading, setLoading] = useState(true)
+  const [avatarToggle, setAvatarToggle] = useState(true)
   const [isNotFound, setNotFound] = useState(false)
   const { username } = match.params
+
+  const authorizedUser = useSelector(selectUser)
 
   const getUser = async (username: string) => {
     try {
@@ -40,11 +44,19 @@ export const Profile: React.FC<React.PropsWithChildren<IProfile>> = ({ match }) 
     }
   }
 
+  const uploadUserAvatar = async (avatar: File): Promise<void> => {
+    try {
+      await UsersService.setUserIcon(username, avatar)
+      setAvatarToggle(!avatarToggle)
+      toasterService.success({ title: 'Change photo', content: 'Photo uploaded successfully' })
+    } catch (error) {
+      toasterService.error({ title: 'Change Photo', content: 'Failed to upload photo' })
+    }
+  }
+
   useEffect(() => {
     getUser(username)
-  }, [username])
-
-  const authorizedUser = useSelector(selectUser)
+  }, [username, avatarToggle])
 
   const { loggedIn, username: authorizedLogin } = authorizedUser
 
@@ -67,7 +79,7 @@ export const Profile: React.FC<React.PropsWithChildren<IProfile>> = ({ match }) 
               <div className={styles.profile_content}>
                 <div className={styles.profile_media}>
                   <Avatar imageUrl={resolveProfileImagePath(username)} customClass={styles.profile_avatar} />
-                  {loggedIn && isPageOwner && <Upload value="Change photo" />}
+                  {loggedIn && isPageOwner && <Upload value="Change photo" handleUpload={uploadUserAvatar} />}
                 </div>
                 <div className={styles.profile_info}>
                   <p className={styles.username}>{username}</p>

--- a/src/pages/profile/Upload/index.tsx
+++ b/src/pages/profile/Upload/index.tsx
@@ -5,12 +5,21 @@ import styles from './Upload.module.scss'
 interface IUpload {
   value: string
   customClass?: string
+  handleUpload: (file: File) => void
 }
 
-export const Upload: React.FC<React.PropsWithChildren<IUpload>> = ({ value, customClass = '' }) => {
+export const Upload: React.FC<React.PropsWithChildren<IUpload>> = ({ value, customClass = '', handleUpload }) => {
   return (
     <label className={`${styles.upload_button} ${customClass}`}>
-      <input type="file" />
+      <input
+        type="file"
+        accept="image/*"
+        onChange={({ target }) => {
+          if (target.files) {
+            handleUpload(target.files[0])
+          }
+        }}
+      />
       {value}
     </label>
   )


### PR DESCRIPTION
**Done**:

- Implement upload user photo mechanism.
- Send real request to API in case of new photo uploading.
- Configure upload component to be reusable.
- Add html5 filters that prevents not image file selection.
- Handle success and failed upload status with toast service.
- Wrap post image and username with LInk component

**Success upload case**:

https://user-images.githubusercontent.com/93332463/141455338-9eb6e92b-be94-493f-b9db-637fa2b02500.mov


**Failed  image upload**

https://user-images.githubusercontent.com/93332463/141455401-c5ae8e3a-3d70-4674-b321-3d113e96b42d.mov


**Unable to select not image type**

https://user-images.githubusercontent.com/93332463/141455507-9a429d29-41c6-4ccb-84f3-963145fbd02f.mov
