### PR TITLE
Feature/#27 post page

### DIFF
--- a/src/components/post/Post.module.scss
+++ b/src/components/post/Post.module.scss
@@ -4,15 +4,15 @@
 .container {
   width: 100%;
   margin-bottom: 20px;
-  box-shadow: 0px 8px 16px 0px rgba(34, 60, 80, 0.2);
-  border-radius: 10px;
-  border: 1px solid $secondary;
 
   @include medium {
     min-width: 150px;
 
     .post {
       padding: 25px;
+    }
+    .post__full {
+      padding: 0;
     }
 
     .post__flex {
@@ -70,6 +70,9 @@
   justify-content: center;
   flex-direction: column;
   padding: 15px;
+  box-shadow: 0px 8px 16px 0px rgba(34, 60, 80, 0.2);
+  border-radius: 10px;
+  border: 1px solid $secondary;
 
   &__flex {
     display: flex;
@@ -154,6 +157,37 @@
     color: $secondary;
     &--padding {
       padding-left: 10px;
+    }
+  }
+
+  &__full {
+    padding: 0;
+    border: none;
+    box-shadow: none;
+
+    .post__info {
+      padding-top: 9px;
+      @include medium {
+        padding-top: 25px;
+        padding-bottom: 40px;
+      }
+    }
+
+    .post__title {
+      font-size: 18px;
+      @include medium {
+        font-size: 24px;
+      }
+    }
+
+    .post__text {
+      display: block;
+      margin-top: 16px;
+      margin-bottom: 0;
+      @include medium {
+        font-size: 16px;
+        margin-top: 24px;
+      }
     }
   }
 }

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -19,7 +19,11 @@ import { Typography } from '../Typography'
 
 import styles from './Post.module.scss'
 
-export const Post: React.FC<React.PropsWithChildren<ISinglePost>> = ({
+interface IPost extends ISinglePost {
+  isFullPost?: boolean
+}
+
+export const Post: React.FC<React.PropsWithChildren<IPost>> = ({
   author,
   date,
   body,
@@ -28,6 +32,7 @@ export const Post: React.FC<React.PropsWithChildren<ISinglePost>> = ({
   countChildren,
   _id,
   __v,
+  isFullPost,
 }) => {
   const [isUpvoted, setUpvoted] = useState(false)
   const [isDownvoted, setDownvoted] = useState(false)
@@ -108,7 +113,7 @@ export const Post: React.FC<React.PropsWithChildren<ISinglePost>> = ({
 
   return (
     <div className={styles.container}>
-      <article className={styles.post}>
+      <article className={isFullPost ? `${styles.post} ${styles.post__full}` : styles.post}>
         <div className={styles.post__flex}>
           <div className={styles['post__author-center']}>
             <div>
@@ -130,9 +135,11 @@ export const Post: React.FC<React.PropsWithChildren<ISinglePost>> = ({
             </Link>
           </Typography>
           <p className={styles.post__text}>{body}</p>
-          <Link to={`${ROUTES.ALL_POST}/${_id}`} className={styles.post__seemore}>
-            see more
-          </Link>
+          {!isFullPost && (
+            <Link to={`${ROUTES.ALL_POST}/${_id}`} className={styles.post__seemore}>
+              see more
+            </Link>
+          )}
         </div>
         <div className={styles['post__bottom--flex']}>
           <div className={styles['post__bottom--center']}>

--- a/src/pages/single-post/SinglePost.module.scss
+++ b/src/pages/single-post/SinglePost.module.scss
@@ -1,2 +1,24 @@
-.SinglePost {
+@import '../../assets/styles/variables.scss';
+@import '../../assets/styles/mixins/breakpoints.scss';
+
+.post-page {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid $secondary;
+  border-radius: 15px;
+  @include medium {
+    margin-top: 48px;
+    padding: 48px 110px;
+  }
+
+  &_error {
+    margin-top: 150px;
+    text-align: center;
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  &_container {
+    max-width: 870px;
+  }
 }

--- a/src/pages/single-post/SinglePost.tsx
+++ b/src/pages/single-post/SinglePost.tsx
@@ -1,14 +1,75 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
+import { PostsService } from '../../API/PostsService'
+import { Container } from '../../components/Container'
 import { Header } from '../../components/Header'
+import { Post } from '../../components/post'
+import { Spinner } from '../../components/Spinner'
+import { ISinglePostResult } from '../../models/SinglePostResult'
 
 import styles from './SinglePost.module.scss'
 
-export const SinglePost = () => {
+interface IPostPage {
+  match: {
+    params: {
+      id: string
+    }
+  }
+}
+
+export const SinglePost: React.FC<React.PropsWithChildren<IPostPage>> = ({ match }) => {
+  const { id } = match.params
+  const [loading, setLoading] = useState(true)
+  const [post, setPost] = useState<Partial<ISinglePostResult>>({})
+  const [isNotFound, setNotFound] = useState(false)
+
+  const getSinglePost = async (id: string): Promise<void> => {
+    try {
+      setLoading(true)
+      setNotFound(false)
+      const response = await PostsService.getSinglePost(id)
+      setPost(response.data)
+    } catch (err) {
+      setNotFound(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    getSinglePost(id)
+  }, [id])
+
+  const { title, body, date, author, upvotes, __v, _id } = post as ISinglePostResult
+
   return (
     <React.Fragment>
-      <Header isSignupPage={true} />
-      <div className={styles.SinglePost}>Single post page</div>
+      <Header />
+      <Container customClass={styles['post-page_container']}>
+        {isNotFound && <div className={styles['post-page_error']}>Not Found Post with id: {id}</div>}
+        {loading ? (
+          <Spinner />
+        ) : (
+          !isNotFound && (
+            <div className={styles['post-page']}>
+              <Post
+                countChildren={0}
+                title={title}
+                body={body}
+                date={date}
+                author={author}
+                upvotes={upvotes}
+                __v={__v}
+                _id={_id}
+                isFullPost={true}
+              />
+              <div> Put Add Comment form here</div>
+              <div> Put Comments list here </div>
+              <div> Put See More button here </div>
+            </div>
+          )
+        )}
+      </Container>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Created basic post page component.
Updated single post to be generic for reuse as shortcut info post and as part of post page.
Implemented filling the post page with real info from API.

**Post page desktop view**
<img width="1439" alt="Screenshot 2021-11-17 at 00 42 21" src="https://user-images.githubusercontent.com/93332463/142078282-97dd8fd7-72a9-426c-b51c-7f94a747f1a2.png">


**Post page mobile view**
<img width="376" alt="Screenshot 2021-11-17 at 00 42 52" src="https://user-images.githubusercontent.com/93332463/142078337-c117512a-2523-4e08-9af8-0cf895147fc8.png">

