### PR TITLE
feature/#21 Add styles to post creation modal

### DIFF
--- a/src/components/PostCreation/PostCreation.module.scss
+++ b/src/components/PostCreation/PostCreation.module.scss
@@ -29,7 +29,6 @@ input[type='text'] {
       font-weight: 500;
       font-size: 40px;
     }
-
   }
 
   &__textField-title {
@@ -42,7 +41,7 @@ input[type='text'] {
     outline: none;
 
     &:focus {
-      border: 2px solid $secondary;
+      background-color: #f8f8f8;
     }
   }
 
@@ -55,10 +54,15 @@ input[type='text'] {
     border-radius: 10px;
     color: $dark-text;
     outline: none;
+    resize: none;
 
     &:focus {
-      border: 2px solid $secondary;
+      background-color: #f8f8f8;
     }
+  }
+
+  &__error-message {
+    position: absolute;
   }
 
   &__require--padding {
@@ -74,7 +78,6 @@ input[type='text'] {
     @include medium {
       justify-content: start;
     }
-
   }
 
   &__button {
@@ -82,4 +85,3 @@ input[type='text'] {
     padding: 10px 35px;
   }
 }
-

--- a/src/components/PostCreation/index.tsx
+++ b/src/components/PostCreation/index.tsx
@@ -62,7 +62,9 @@ export const PostCreationModal: React.FC<{ onCrossBtnHandler: React.MouseEventHa
             onBlur={formik.handleBlur}
           />
           <div className={styles['postModal__require--padding']}>
-            {formik.touched.title && formik.errors.title && <span>{formik.errors.title}</span>}
+            {formik.touched.title && formik.errors.title && (
+              <div className={styles['postModal__error-message']}>{formik.errors.title}</div>
+            )}
           </div>
           <textarea
             className={styles['postModal__textField-body']}
@@ -73,7 +75,9 @@ export const PostCreationModal: React.FC<{ onCrossBtnHandler: React.MouseEventHa
             onBlur={formik.handleBlur}
           />
           <div className={styles['postModal__require--padding']}>
-            {formik.touched.body && formik.errors.body && <span>{formik.errors.body}</span>}
+            {formik.touched.body && formik.errors.body && (
+              <div className={styles['postModal__error-message']}>{formik.errors.body}</div>
+            )}
           </div>
           <div className={styles['postModal__button--justify']}>
             <Button


### PR DESCRIPTION
1. Add styles to field form.
2. Add styles to error message.
Before
![image](https://user-images.githubusercontent.com/93322466/142613744-dc86f783-86c0-4706-b25f-b894d9634f7a.png)
After
![image](https://user-images.githubusercontent.com/93322466/142613561-d9582e03-e781-4557-bd79-7cfecd48818a.png)
